### PR TITLE
Add npm workspaces monorepo with example tool package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# hello-codex
+# Tools Monorepo
+
+This repository is structured as a monorepo using npm workspaces. Each package is located in the `packages` directory and can be published under the `@michaelhartmayer` scope.
+
+## Usage
+
+Install packages with npm and import the tools:
+
+```bash
+npm install @michaelhartmayer/tool
+```
+
+```ts
+import { tool } from '@michaelhartmayer/tool';
+```
+
+## Development
+
+- Install dependencies: `npm install`
+- Build all packages: `npm run build`
+
+New packages can be added under `packages/<name>` with their own `package.json`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,40 @@
+{
+  "name": "tools-monorepo",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tools-monorepo",
+      "version": "1.0.0",
+      "workspaces": [
+        "packages/*"
+      ],
+      "devDependencies": {
+        "typescript": "^5.2.2"
+      }
+    },
+    "node_modules/@michaelhartmayer/tool": {
+      "resolved": "packages/tool",
+      "link": true
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/tool": {
+      "name": "@michaelhartmayer/tool",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "tools-monorepo",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
+  "scripts": {
+    "build": "npm run build --workspaces",
+    "test": "echo \"No tests\""
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2"
+  }
+}

--- a/packages/tool/dist/index.d.ts
+++ b/packages/tool/dist/index.d.ts
@@ -1,0 +1,1 @@
+export declare function tool(): string;

--- a/packages/tool/dist/index.js
+++ b/packages/tool/dist/index.js
@@ -1,0 +1,6 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.tool = tool;
+function tool() {
+    return 'Hello from tool';
+}

--- a/packages/tool/package.json
+++ b/packages/tool/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@michaelhartmayer/tool",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --project tsconfig.json"
+  }
+}

--- a/packages/tool/src/index.ts
+++ b/packages/tool/src/index.ts
@@ -1,0 +1,3 @@
+export function tool(): string {
+  return 'Hello from tool';
+}

--- a/packages/tool/tsconfig.json
+++ b/packages/tool/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
## Summary
- initialize an npm workspaces monorepo
- add a sample `@michaelhartmayer/tool` package with TypeScript source
- document how to use and develop the monorepo

## Testing
- `npm install`
- `npm run build --workspaces`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865ba014b688323936df4af6a1ea493